### PR TITLE
fix: calculate truncated text size (with `maxLines`) correctly

### DIFF
--- a/lib/src/text_view.dart
+++ b/lib/src/text_view.dart
@@ -40,6 +40,8 @@ class RichTextView extends StatefulWidget {
   final RegexOptions regexOptions;
   final TextAlign textAlign;
 
+  /// Whether to show "Show more" or "Show less" text
+  /// that truncates/expands the text.
   final bool toggleTruncate;
 
   RichTextView({
@@ -222,7 +224,7 @@ class _RichTextViewState extends State<RichTextView> {
         var textSpan;
         if (textPainter.didExceedMaxLines) {
           final pos = textPainter.getPositionForOffset(Offset(
-            textSize.width - linkSize.width,
+            textSize.width - (widget.toggleTruncate ? linkSize.width : 0),
             textSize.height,
           ));
           final endIndex = textPainter.getOffsetBefore(pos.offset);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rich_text_view
 description: A simple yet powerful rich text view that supports mention, hashtag, email, url and see more.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/nelsonweze/rich_text_view
 
 environment:


### PR DESCRIPTION
fix: calculate truncated text size (with `maxLines`) correctly