### PR TITLE
fix: add ellipsis (…) at the end of the text when text is truncated using `maxLines` and "Show more" is hidden (`toggleTruncate` is false)

### DIFF
--- a/lib/src/text_view.dart
+++ b/lib/src/text_view.dart
@@ -242,8 +242,8 @@ class _RichTextViewState extends State<RichTextView> {
               ? parseText(widget.text)
               : parseText(
                   widget.text.substring(0, max(endIndex!, 0)) +
-                      // Append the ellipsis if `toggleTruncate`
-                      // ("Show more"/"Show less" is not displayed)
+                      // Append the ellipsis if `toggleTruncate` is false
+                      // (i.e. "Show more"/"Show less" is not shown)
                       // and the text is truncated.
                       (!widget.toggleTruncate ? ellipsis : ''),
                 );

--- a/lib/src/text_view.dart
+++ b/lib/src/text_view.dart
@@ -240,7 +240,13 @@ class _RichTextViewState extends State<RichTextView> {
 
           final textChildren = _expanded
               ? parseText(widget.text)
-              : parseText(widget.text.substring(0, max(endIndex!, 0)) + '…');
+              : parseText(
+                  widget.text.substring(0, max(endIndex!, 0)) +
+                      // Append the ellipsis if `toggleTruncate`
+                      // ("Show more"/"Show less" is not displayed)
+                      // and the text is truncated.
+                      (!widget.toggleTruncate ? ellipsis : ''),
+                );
 
           final lastTextSpan = textChildren
               .lastWhereOrNull((child) => child is TextSpan) as TextSpan?;

--- a/lib/src/text_view.dart
+++ b/lib/src/text_view.dart
@@ -18,7 +18,6 @@ class RichTextView extends StatefulWidget {
   final TextStyle linkStyle;
   final TextDirection? textDirection;
   final bool softWrap;
-  final TextOverflow overflow;
   final double textScaleFactor;
   final int? maxLines;
   final StrutStyle? strutStyle;
@@ -40,8 +39,9 @@ class RichTextView extends StatefulWidget {
   final RegexOptions regexOptions;
   final TextAlign textAlign;
 
-  /// Whether to show "Show more" or "Show less" text
-  /// that truncates/expands the text.
+  /// Whether to show "Show more" or "Show less" link at the end
+  /// of the text. Tapping on the button will toggle the text
+  /// between truncated and expanded text.
   final bool toggleTruncate;
 
   RichTextView({
@@ -56,7 +56,6 @@ class RichTextView extends StatefulWidget {
     this.textAlign = TextAlign.start,
     this.textDirection = TextDirection.ltr,
     this.softWrap = true,
-    this.overflow = TextOverflow.clip,
     this.textScaleFactor = 1.0,
     this.strutStyle,
     this.textWidthBasis = TextWidthBasis.parent,
@@ -217,6 +216,11 @@ class _RichTextViewState extends State<RichTextView> {
         textPainter.layout(minWidth: constraints.minWidth, maxWidth: maxWidth);
         final linkSize = textPainter.size;
 
+        final ellipsis = '…';
+        textPainter.text = TextSpan(text: ellipsis, style: _style);
+        textPainter.layout(minWidth: constraints.minWidth, maxWidth: maxWidth);
+        final ellipsisSize = textPainter.size;
+
         textPainter.text = content;
         textPainter.layout(minWidth: constraints.minWidth, maxWidth: maxWidth);
         final textSize = textPainter.size;
@@ -224,14 +228,19 @@ class _RichTextViewState extends State<RichTextView> {
         var textSpan;
         if (textPainter.didExceedMaxLines) {
           final pos = textPainter.getPositionForOffset(Offset(
-            textSize.width - (widget.toggleTruncate ? linkSize.width : 0),
+            // "Show more"/"Show less" will be appended to the end of the text
+            // if `toggleTruncate` is true. Otherwise, ellipsis will be appended.
+            // Therefore, we need to subtract the width of the appended text
+            // from the total width of the text.
+            textSize.width -
+                (widget.toggleTruncate ? linkSize.width : ellipsisSize.width),
             textSize.height,
           ));
           final endIndex = textPainter.getOffsetBefore(pos.offset);
 
           final textChildren = _expanded
               ? parseText(widget.text)
-              : parseText(widget.text.substring(0, max(endIndex!, 0)));
+              : parseText(widget.text.substring(0, max(endIndex!, 0)) + '…');
 
           final lastTextSpan = textChildren
               .lastWhereOrNull((child) => child is TextSpan) as TextSpan?;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rich_text_view
 description: A simple yet powerful rich text view that supports mention, hashtag, email, url and see more.
-version: 1.6.1
+version: 1.7.0
 homepage: https://github.com/nelsonweze/rich_text_view
 
 environment:


### PR DESCRIPTION
fix: add ellipsis (…) at the end of the text when text is truncated using `maxLines` and "Show more" is hidden (`toggleTruncate` is false)